### PR TITLE
feat(package): new command package to generate documentation for a given golang package

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/b5/outline/lib"
+	"github.com/spf13/cobra"
+	parseutil "gopkg.in/src-d/go-parse-utils.v1"
+)
+
+// PackageCmd extracts and execute outline documents from a go package against a template",
+var PackageCmd = &cobra.Command{
+	Use:     "package",
+	Aliases: []string{"pkg"},
+	Short:   "exctract and execute outline documents from a go package against a template",
+	Long:    ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		t := template.Must(template.New("mdIndex").Parse(mdIndex))
+
+		str, err := cmd.Flags().GetString("template")
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		if str != "" {
+			t, err = template.ParseFiles(str)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
+
+		docs := map[string]*lib.Doc{}
+		for _, pkg := range args {
+			pkg, err := parseutil.PackageAST(pkg)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			for _, f := range pkg.Files {
+				for _, c := range f.Comments {
+					buf := strings.NewReader(c.Text())
+					read, err := lib.Parse(buf)
+					if err != nil {
+						fmt.Println(err.Error())
+						os.Exit(1)
+					}
+
+					for _, doc := range read {
+						if found, ok := docs[doc.Name]; ok {
+							merge(found, doc)
+							continue
+						}
+
+						docs[doc.Name] = doc
+					}
+				}
+			}
+		}
+
+		noSort, err := cmd.Flags().GetBool("no-sort")
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		var list lib.Docs
+		for _, doc := range docs {
+			list = append(list, doc)
+		}
+
+		if !noSort {
+			list.Sort()
+		}
+
+		if err := t.Execute(os.Stdout, list); err != nil {
+			fmt.Println(err.Error())
+			os.Exit(1)
+		}
+	},
+}
+
+func merge(a, b *lib.Doc) {
+	if a.Description == "" {
+		a.Description = b.Description
+	}
+
+	if a.Path == "" {
+		a.Path = b.Path
+	}
+
+	a.Types = append(a.Types, b.Types...)
+	a.Functions = append(a.Functions, b.Functions...)
+}
+
+func init() {
+	PackageCmd.Flags().StringP("template", "t", "", "template file to load. overrides preset")
+	PackageCmd.Flags().Bool("no-sort", false, "don't alpha-sort fields & outline documents")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,5 +36,6 @@ func init() {
 	RootCmd.AddCommand(
 		FmtCmd,
 		TemplateCmd,
+		PackageCmd,
 	)
 }


### PR DESCRIPTION
This is a quick and dirty implementation that allows to recover all the documentation blocks from a given golang package and generate the outline output.

Each block can be a outline partial comment, this docs are merged by name, to give a complete output.

Input: 
```go

// LoadModule loads the os module.
// It is concurrency-safe and idempotent.
//
//   outline: os
//     os provides a platform-independent interface to operating system functionality.
//     path: os
func LoadModule() (starlark.StringDict, error) {
...
}

// Chdir changes the current working directory to the named directory.
//
//   outline: os
//     functions:
//       chdir(dir)
//         changes the current working directory to the named directory.
//         params:
//           dir string
//             target dir
func Chdir(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
...
}

// Getwd returns a rooted path name corresponding to the current directory.
//
//   outline: os
//     functions:
//       getwd() dir
//         returns a rooted path name corresponding to the current directory.
func Getwd(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
...
}
```

Outputs:

```md
# os
os provides a platform-independent interface to operating system functionality.

## Functions

#### `chdir(dir)`
changes the current working directory to the named directory.

**parameters:**

| name | type | description |
|------|------|-------------|
| `dir` | `string` | target dir |


#### `getwd() dir`
returns a rooted path name corresponding to the current directory.
``

